### PR TITLE
Change "Android is upgrading" Alert Dialog theme to Material Design

### DIFF
--- a/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
+++ b/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
@@ -5295,7 +5295,8 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                             PackageManager.FEATURE_TELEVISION)) {
                         theme = com.android.internal.R.style.Theme_Leanback_Dialog_Alert;
                     } else if (SystemProperties.get("ro.product.board").equals("tuna")) {
-                        theme = com.android.internal.R.style.Theme_Holo_Dialog_Alert;
+                        //theme = com.android.internal.R.style.Theme_Holo_Dialog_Alert;
+                        theme = com.android.internal.R.style.Theme_Material_Dialog_Alert;
                     } else {
                         theme = 0;
                     }


### PR DESCRIPTION
I didn't notice any major burn-in effect with  AlertDialog being Dark Material Design. 
